### PR TITLE
Add window_command to Engine

### DIFF
--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -16,12 +16,10 @@ use amethyst::ecs::{Component, DenseVecStorage, ECSBundle, Fetch, FetchMut, Join
 use amethyst::ecs::audio::DjBundle;
 use amethyst::ecs::input::{InputBundle, InputHandler};
 use amethyst::ecs::rendering::{Factory, MaterialComponent, MeshComponent, RenderBundle};
-use amethyst::ecs::rendering::events::WindowModifierEvent;
 use amethyst::ecs::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst::prelude::*;
 use amethyst::renderer::Config as DisplayConfig;
 use amethyst::renderer::prelude::*;
-use amethyst::shrev::EventHandler;
 use amethyst::timing::Time;
 use futures::{Future, IntoFuture};
 
@@ -339,20 +337,11 @@ impl State for Pong {
                 score_sfx,
             });
             // Sets the cursor hidden when the mouse is hovering the pong window.
-            if let Some(mut window_events) = engine
-                .world
-                .res
-                .try_fetch_mut::<EventHandler<WindowModifierEvent>>(0)
-            {
-                window_events.write_single(WindowModifierEvent {
-                    modify: Box::new(|win| {
-                        win.set_cursor_state(winit::CursorState::Hide)
-                            .ok()
-                            .expect("Could not hide mouse cursor")
-                    }),
-                });
-            }
-
+            engine.window_command(|win| {
+                win.set_cursor_state(winit::CursorState::Hide)
+                    .ok()
+                    .expect("Could not hide mouse cursor")
+            });
             let have_output = engine.world.read_resource::<Option<Output>>().is_some();
 
             if have_output {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rayon::ThreadPool;
+use renderer::types::Window;
+use shrev::EventHandler;
 
 use ecs::World;
+use ecs::rendering::WindowModifierEvent;
 
 /// User-facing engine handle.
 pub struct Engine {
@@ -25,5 +28,19 @@ impl Engine {
             pool: pool,
             world: world,
         }
+    }
+
+    /// Sends a command to the game's inner window
+    pub fn window_command<F>(&mut self, command: F)
+    where
+        F: Fn(&mut Window) -> () + Send + Sync + 'static,
+    {
+        self.world
+            .res
+            .try_fetch_mut::<EventHandler<WindowModifierEvent>>(0)
+            .expect("Command queue for the Window not found!")
+            .write_single(WindowModifierEvent {
+                modify: Box::new(command),
+            });
     }
 }


### PR DESCRIPTION
The window_command function makes modifying the window from a state significantly less verbose.  It could also look similar to this for Systems as well if we used a mpsc::channel or SmallVec instead of shrev.