### PR TITLE
Refactor Transform in amethyst_core (and reformat amethyst_assets)

### DIFF
--- a/amethyst_assets/src/prefab/impls.rs
+++ b/amethyst_assets/src/prefab/impls.rs
@@ -1,7 +1,7 @@
 use amethyst_core::{
+    nalgebra::Real,
     specs::{Entity, WriteStorage},
     Named, Transform,
-    nalgebra::Real
 };
 use amethyst_error::Error;
 
@@ -41,7 +41,7 @@ where
 }
 
 impl<'a, N: Real> PrefabData<'a> for Transform<N> {
-    type SystemData =  WriteStorage<'a, Transform<N>>;
+    type SystemData = WriteStorage<'a, Transform<N>>;
     type Result = ();
 
     fn add_to_entity(

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -105,7 +105,7 @@ impl<N: Real> Transform<N> {
 
     /// Returns the local object matrix for the transform.
     ///
-    /// Combined with the parent's `GlobalTransform` component it gives
+    /// Combined with the `global_matrix` field from the parent's `Transform` component it gives
     /// the global (or world) matrix for the current entity.
     #[inline]
     pub fn matrix(&self) -> Matrix4<N> {


### PR DESCRIPTION
I attempted to refactor Transforms in amethyst_core's tests. However, I couldn't run them since `cargo test` in amethyst_core attempts to build amethyst_audio, amethyst_renderer…
I'll next refactor amethyst_audio.